### PR TITLE
Handle video frame queue overflow

### DIFF
--- a/gate_app.py
+++ b/gate_app.py
@@ -396,7 +396,17 @@ class FFMpegPipeGrabber(threading.Thread):
                         try:
                             self.q.put(img, timeout=0.01)
                         except queue.Full:
-                            logging.info("[VIDEO] kolejka pełna – klatka odrzucona")
+                            try:
+                                self.q.get_nowait()
+                            except queue.Empty:
+                                pass
+                            try:
+                                self.q.put_nowait(img)
+                            except queue.Full:
+                                pass
+                            if time.time() - last_warn > 5.0:
+                                logging.info("[VIDEO] kolejka pełna – usunięto najstarszą klatkę")
+                                last_warn = time.time()
                     else:
                         logging.info("[VIDEO] nieudany odczyt klatki (decode JPEG failed)")
                 else:
@@ -489,11 +499,17 @@ class AlprExec:
             return self._sudo()+["docker","exec", self.container, "bash","-lc",
                                  f"test -s /data/{shlex.quote(base)} && stat -c%s /data/{shlex.quote(base)} || echo 0"]
 
-        # Poczekaj aż plik „pojawi się” w kontenerze i będzie >0 B (do ~200 ms)
+        # Poczekaj aż plik „pojawi się” w kontenerze i będzie >0 B (do ~1 s)
         size_ok = False
-        for _ in range(10):
+        for _ in range(50):
             try:
-                rsz = subprocess.run(_size_cmd(), stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=0.3)
+                rsz = subprocess.run(
+                    _size_cmd(),
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                    timeout=0.3,
+                )
                 sz = int((rsz.stdout or "0").strip() or "0")
                 if sz > 0:
                     size_ok = True
@@ -504,6 +520,7 @@ class AlprExec:
 
         if not size_ok:
             logging.info(f"[ALPR] plik jeszcze niewidoczny lub pusty w kontenerze: {base}")
+            return []
 
         def _run_once(ctry):
             return subprocess.run(_alpr_cmd(ctry), stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=timeout)
@@ -527,7 +544,10 @@ class AlprExec:
             time.sleep(0.04)
 
         if data is None:
-            logging.info(f"[ALPR] rc!=0 stderr='{last_err.strip()[:200]}'")
+            if "Unknown file type" in last_err or "Unsupported image type" in last_err:
+                logging.info(f"[ALPR] nierozpoznany format obrazu: {base}")
+            else:
+                logging.info(f"[ALPR] rc!=0 stderr='{last_err.strip()[:200]}'")
             return []
 
         out = []
@@ -599,20 +619,32 @@ class Prefilter(threading.Thread):
         self.frame_id = 0
 
     def _atomic_write(self, path_tmp, path_final, img, ext):
-        # zapis do pliku tymczasowego
-        if ext in ("jpg", "jpeg"):
-            cv2.imwrite(path_tmp, img, [int(cv2.IMWRITE_JPEG_QUALITY), 85])
-        else:
-            cv2.imwrite(path_tmp, img)
-        # fsync, aby dopchnąć na dysk/wolumin
         try:
-            fd = os.open(path_tmp, os.O_RDONLY)
-            os.fsync(fd)
-            os.close(fd)
+            # zapis do pliku tymczasowego
+            if ext in ("jpg", "jpeg"):
+                ok = cv2.imwrite(path_tmp, img, [int(cv2.IMWRITE_JPEG_QUALITY), 85])
+            else:
+                ok = cv2.imwrite(path_tmp, img)
+            if not ok:
+                raise IOError("cv2.imwrite returned False")
+            # fsync, aby dopchnąć na dysk/wolumin
+            try:
+                fd = os.open(path_tmp, os.O_RDONLY)
+                os.fsync(fd)
+                os.close(fd)
+            except Exception:
+                pass
+            # atomowe przeniesienie
+            os.replace(path_tmp, path_final)
+            return True
         except Exception:
-            pass
-        # atomowe przeniesienie
-        os.replace(path_tmp, path_final)
+            logging.exception(f"[ROI] zapis {path_final} nie powiódł się")
+            try:
+                if os.path.exists(path_tmp):
+                    os.remove(path_tmp)
+            except Exception:
+                pass
+            return False
 
     def run(self):
         while not self.stop_flag.is_set():
@@ -649,9 +681,11 @@ class Prefilter(threading.Thread):
             ext = (cfg.get("ALPR_IMAGE_FORMAT", "jpg") or "jpg").lower()
             if ext not in ("jpg", "jpeg", "png"): ext = "jpg"
             roi_name = f"roi_{int(ts*1000)}_{self.frame_id}.{ext}"
-            roi_tmp = os.path.join(ALPR_TMP_DIR, "." + roi_name + ".tmp")
+            # plik tymczasowy musi zachować rozszerzenie (cv2 opiera się na nim)
+            roi_tmp = os.path.join(ALPR_TMP_DIR, f".tmp_{roi_name}")
             roi_path = os.path.join(ALPR_TMP_DIR, roi_name)
-            self._atomic_write(roi_tmp, roi_path, roi, ext)
+            if not self._atomic_write(roi_tmp, roi_path, roi, ext):
+                continue
 
             # debug: zapisz ROI i full
             if cfg.get("SAVE_ALL_TEST_FRAMES", True):


### PR DESCRIPTION
## Summary
- Drop oldest frame when video queue is full instead of repeatedly logging drops
- Throttle queue overflow logs to reduce spam
- Preserve ROI image extension in temp files and guard against write failures
- Wait up to a second for ROI file visibility and skip ALPR if the file never appears
- Log unsupported ALPR image types separately from other errors

## Testing
- `python -m py_compile gate_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1d326793c83329b12634fee0edbac