### PR TITLE
Improve ALPR temp dir handling and wait logic

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -29,6 +29,8 @@ ALPR_COUNTRY: "eu"
 ALPR_DETECT_REGION: true       # false = próbuj OCR bez wykrycia regionu tablicy (luźniejsze testy)
 ALPR_CONFIDENCE_MIN: 85.0
 ALPR_EXTRA_ARGS: ""            # np. "--topn 20 --skip_region_confidence"
+# Wspólny katalog na pliki ROI; gdy uruchamiasz bez Dockera możesz ustawić np. "./alprtmp"
+# ALPR_TMP_DIR: "./alprtmp"
 
 # --- Whitelist (hot-reload, także zmiana ścieżki) ---
 WHITELIST_FILE: "./whitelist.txt"


### PR DESCRIPTION
## Summary
- fallback to a writable `ALPR_TMP_DIR` when `/shared/alprtmp` is missing
- log the resolved temp directory and allow overriding via config or env
- extend the wait for ROI files inside the ALPR container to ~3 seconds
- document optional `ALPR_TMP_DIR` in `config.yaml`

## Testing
- `python -m py_compile gate_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1db608ff483329cc2838a095869d7